### PR TITLE
ideas/2024: propose an analytics project (time budgeted builds)

### DIFF
--- a/ideas/2024.md
+++ b/ideas/2024.md
@@ -188,35 +188,26 @@ Possible mentors:
  
  Rating: Hard
 
-
 ### Nixpkgs analytics: [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review) with a time-budget
 
-This project is a small step in analyzing and understanding the data generated
-by the Nixpkgs' fifteen years of modeling (bootstrapping, building and testing)
-"much of the world of open source software". This data includes:
+Nixpkgs and its infrastructure feature fifteen years of history of the open source software: in the form of build and test logs, dependency graphs, and conversations. Compared to the opportunities offered by this data, we'll attempt a modest task: write a version of [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review) or [`nix-fast-build`](https://github.com/Mic92/nix-fast-build) that can follow a fixed time-budget.
 
-- [Hydra](https://hydra.nixos.org/job/nixpkgs/trunk/python311Packages.torch.aarch64-linux)'s evaluation errors, output paths, [build times](https://hydra.nixos.org/build/250198091#tabs-details), and build logs.
-- The `.narinfo` files stored by https://cache.nixos.org, which together describe runtime dependency graphs between packages built by Hydra.
-- Logs for the builds and `passthru` tests run by [Ofborg](https://logs.ofborg.org/).
-- The [Nixpkgs](https://github.com/NixOS/nixpkgs) Git repository, where each
-  revision includes Nix code that can be evaluated or built, as well as
-  human-readable comments left by maintainers possibly providing insights into
-  the evolution of coding patterns and conventions used by Nixpkgs, as well as
-  into the details of upstream projects.
-- The NixOS/Nixpkgs GitHub repository, which features conversations in GitHub issues and code reviews.
-- IRC, Discourse, and Matrix logs.
+The problem decomposes into at least three tasks:
+- Obtaining the data from Hydra and preparing it for redistribution and downstream usage.
+- Working out a statistical model for the build times, including online update rules.
+- Writing the evaluation and build scheduler that can consult such a model.
 
-Some of this data can be explored and visualized in Grafana hosted at https://monitoring.nixos.org/grafana.
-This data allows tools like [nix-index](https://github.com/nix-community/nix-index/) (`nix-locate`, `comma`, [envfs](https://github.com/Mic92/envfs), etc.) to exist.
-Nonetheless, we currently lack tools to use this data to (conveniently) answer
-sometimes very simple queries like "how long has a given package been taking to
-build on average". To contrast, our ambition could have been to reason about questions such as "how likely is the next build to succeed?", "how long is it likely to take until termination?", "given a Nixpkgs revision and a PR, what attributes is it likely to break?", "given Nixpkgs git history and a failing attribute, which commit is likely to have introduced the breakage?", "why was a given change introduced?". Some of these questions have brute-force solutions: termination times can be obtained by executing the builds, the offending commit may be found by bisection. The accumulated data offers us an opportunity to consult a model prior to performing the expensive computation.
-
-In this project we'll attempt a modest task: write a version of [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review) or [`nix-fast-build`](https://github.com/Mic92/nix-fast-build) that can be given a time-budget to follow. The program would use historical data to estimate each package's contribution to the time complexity of the full review. The program would discard packages that "do not fit into the budget" and report their build status as "uncertain". When the observed build times deviate from the estimates, the program would dynamically adjust and schedule fewer or more builds as appropriate. The program would require a calibration procedure to attune to specific builders. Some sort of a simple linear model should suffice for the initial implementation.
-
-Skills: the project might take understanding the codebase of [`nix-eval-jobs`](https://github.com/nix-community/nix-eval-jobs) and [`nix-fast-build`](https://github.com/Mic92/nix-fast-build) in order to learn how to control and schedule nix evaluation and builds; experience of working with data and the basic numerical sympathy would be helpful.
-
-Rating: Medium
+Rating: Hard
 
 Possible mentors
 - [@SomeoneSerge](https://github.com/SomeoneSerge/)
+
+Skills: designing and implementing algorithms; experience of working with data and the basic numerical sympathy will be helpful.
+
+References:
+
+- [Hydra](https://hydra.nixos.org/job/nixpkgs/trunk/python311Packages.torch.aarch64-linux)'s evaluation errors, output paths, [build times](https://hydra.nixos.org/build/250198091#tabs-details), and build logs.
+- [Ofborg logs](https://logs.ofborg.org/).
+- Examples of handling scheduling: [`nix-eval-jobs`](https://github.com/nix-community/nix-eval-jobs) and [`nix-fast-build`](https://github.com/Mic92/nix-fast-build).
+- Nixpkgs infrastructure's [grafana](https://monitoring.nixos.org/grafana).
+- Examples of compacting and handling data: [nix-index](https://github.com/nix-community/nix-index/), [envfs](https://github.com/Mic92/envfs).

--- a/ideas/2024.md
+++ b/ideas/2024.md
@@ -187,3 +187,36 @@ Possible mentors:
  - [@Ericson2314](https://github.com/Ericson2314)
  
  Rating: Hard
+
+
+### Nixpkgs analytics: [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review) with a time-budget
+
+This project is a small step in analyzing and understanding the data generated
+by the Nixpkgs' fifteen years of modeling (bootstrapping, building and testing)
+"much of the world of open source software". This data includes:
+
+- [Hydra](https://hydra.nixos.org/job/nixpkgs/trunk/python311Packages.torch.aarch64-linux)'s evaluation errors, output paths, [build times](https://hydra.nixos.org/build/250198091#tabs-details), and build logs.
+- The `.narinfo` files stored by https://cache.nixos.org, which together describe runtime dependency graphs between packages built by Hydra.
+- Logs for the builds and `passthru` tests run by [Ofborg](https://logs.ofborg.org/).
+- The [Nixpkgs](https://github.com/NixOS/nixpkgs) Git repository, where each
+  revision includes Nix code that can be evaluated or built, as well as
+  human-readable comments left by maintainers possibly providing insights into
+  the evolution of coding patterns and conventions used by Nixpkgs, as well as
+  into the details of upstream projects.
+- The NixOS/Nixpkgs GitHub repository, which features conversations in GitHub issues and code reviews.
+- IRC, Discourse, and Matrix logs.
+
+Some of this data can be explored and visualized in Grafana hosted at https://monitoring.nixos.org/grafana.
+This data allows tools like [nix-index](https://github.com/nix-community/nix-index/) (`nix-locate`, `comma`, [envfs](https://github.com/Mic92/envfs), etc.) to exist.
+Nonetheless, we currently lack tools to use this data to (conveniently) answer
+sometimes very simple queries like "how long has a given package been taking to
+build on average". To contrast, our ambition could have been to reason about questions such as "how likely is the next build to succeed?", "how long is it likely to take until termination?", "given a Nixpkgs revision and a PR, what attributes is it likely to break?", "given Nixpkgs git history and a failing attribute, which commit is likely to have introduced the breakage?", "why was a given change introduced?". Some of these questions have brute-force solutions: termination times can be obtained by executing the builds, the offending commit may be found by bisection. The accumulated data offers us an opportunity to consult a model prior to performing the expensive computation.
+
+In this project we'll attempt a modest task: write a version of [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review) or [`nix-fast-build`](https://github.com/Mic92/nix-fast-build) that can be given a time-budget to follow. The program would use historical data to estimate each package's contribution to the time complexity of the full review. The program would discard packages that "do not fit into the budget" and report their build status as "uncertain". When the observed build times deviate from the estimates, the program would dynamically adjust and schedule fewer or more builds as appropriate. The program would require a calibration procedure to attune to specific builders. Some sort of a simple linear model should suffice for the initial implementation.
+
+Skills: the project might take understanding the codebase of [`nix-eval-jobs`](https://github.com/nix-community/nix-eval-jobs) and [`nix-fast-build`](https://github.com/Mic92/nix-fast-build) in order to learn how to control and schedule nix evaluation and builds; experience of working with data and the basic numerical sympathy would be helpful.
+
+Rating: Medium
+
+Possible mentors
+- [@SomeoneSerge](https://github.com/SomeoneSerge/)


### PR DESCRIPTION
I'd like to CC @Mic92, @RaitoBezarius, @GuillaumeDesforges, @GaetanLepage, @ConnorBaker, and @samuela for comments and as potential "potential mentors" (e.g. I've never looked into the implementations of nix-index, nix-eval-jobs, nix-fast-builds, etc so I may lack some of the expertise required for the project to succeed _in time_)

I didn't write this up but I think one of the prerequisites of a clean solution is the problem of identifying derivations from different nixpkgs instantiations (different revisions, different `config` arguments, etc), which by design "lack identity". What we can easily match is e.g. nixpkgs' attribute paths. However, derivations overridden/defined in e.g. let-in expressions will have non-trivial contributions to the total cost and we need to be able to identify these